### PR TITLE
Improving the cache on the CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,9 +15,9 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: |
-            $HOME/opt
-            $HOME/.ccache
-            $GITHUB_WORKSPACE/_data
+            ~/opt
+            ~/.ccache
+            ./_data
           key: ccache-${{ runner.os }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-
       - name: Set paths
@@ -65,10 +65,11 @@ jobs:
     - uses: actions/cache/restore@v4
       with:
         path: |
-          $HOME/opt
-          $HOME/.ccache
-          $GITHUB_WORKSPACE/_data
+          ~/opt
+          ~/.ccache
+          ./_data
         key: ccache-${{ runner.os }}-${{ github.sha }}
+        fail-on-cache-miss: true
 
     - name: Set up Python 3.8
       uses: actions/setup-python@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,7 @@
-# This is a basic workflow to help you get started with Actions
+name: CI - plumed tutorials -
 
-name: CI
-
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on: [push, pull_request]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -63,18 +58,22 @@ jobs:
             ./_data
           key: build-${{ runner.os }}-${{ github.sha }}
 
-  # This workflow contains a job called "build"
   build:
     needs: setup
     strategy:
       matrix:
         replica: [0, 1]
-    # The type of runner that the job will run on
+        # I'd wish to use something like ${{ strategy.job-total }} the get the 
+        #number of current jobs of the matrix, but things could go wrong in case
+        #of adding a "special" strategy or something similar.
+        # with env: REPLICAS there are 2 things to change (replica and REPLICAS),
+        #but at a least no need to update a line that can be lost further in the yaml
+    env:
+      REPLICAS: 2
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+
     - uses: actions/checkout@v4
 
     - uses: actions/cache/restore@v4
@@ -114,12 +113,12 @@ jobs:
       run: | 
         python --version
         # N.B. If you adjust the number of replicas used here you need to adjust the liquid syntax in summary.md that builds the total number of lessons that use each action 
-        python build_manual.py --nreplicas 2 --replica ${{matrix.replica}}
-    - name: Run
+        python build_manual.py --nreplicas $REPLICAS --replica ${{matrix.replica}}
+    - name: Compile lessons
       run: |
         python --version
         # N.B. If you adjust the number of replicas used here you need to adjust the liquid syntax in summary.md that builds the total number of lessons that use each action 
-        python compile.py --nreplicas 2 --replica ${{matrix.replica}}
+        python compile.py --nreplicas $REPLICAS --replica ${{matrix.replica}}
         cp $(plumed info --root)/json/syntax.json syntax.${{matrix.replica}}.json
     - name: Create tar ball
       run: |
@@ -138,9 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v4
     - name: Download artifacts
       uses: actions/download-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/cache@v4
         with:
           path: |
@@ -129,7 +130,7 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v4
     - name: Download artifacts
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v3
     - name: Set up Python 3.8
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,6 @@ jobs:
             sudo apt install libfftw3-dev gsl-bin libgsl0-dev libboost-serialization-dev
             sudo apt install ccache
             sudo apt-get update
-            git clone --bare https://github.com/plumed/plumed2.git
             sudo ln -s ccache /usr/local/bin/mpic++
             export PATH=/usr/lib/ccache:${PATH}
             ccache -s

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,47 @@ on: [push, pull_request]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/opt
+            ~/.ccache
+          key: ccache-${{ runner.os }}-${{ github.sha }}
+          restore-keys: ccache-${{ runner.os }}-
+      - name: Set paths
+        run: |
+              echo "$HOME/opt/bin" >> $GITHUB_PATH
+              echo "CPATH=$HOME/opt/include:$HOME/opt/libtorch/include/torch/csrc/api/include/:$HOME/opt/libtorch/include/:$HOME/opt/libtorch/include/torch:$CPATH" >> $GITHUB_ENV
+              echo "INCLUDE=$HOME/opt/include:$HOME/opt/libtorch/include/torch/csrc/api/include/:$HOME/opt/libtorch/include/:$HOME/opt/libtorch/include/torch:$INCLUDE" >> $GITHUB_ENV
+              echo "LIBRARY_PATH=$HOME/opt/lib:$HOME/opt/libtorch/lib:$LIBRARY_PATH" >> $GITHUB_ENV
+              echo "LD_LIBRARY_PATH=$HOME/opt/lib:$HOME/opt/libtorch/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+              echo "PYTHONPATH=$HOME/opt/lib/plumed/python:$PYTHONPATH" >> $GITHUB_ENV
+              # needed to avoid MPI warning
+              echo "OMPI_MCA_btl=^openib" >> $GITHUB_ENV
+      - name: Install software
+        run: |
+            sudo apt update
+            sudo apt install mpi-default-bin mpi-default-dev
+            sudo apt install libfftw3-dev gsl-bin libgsl0-dev libboost-serialization-dev
+            sudo apt install ccache
+            sudo apt-get update
+            git clone --bare https://github.com/plumed/plumed2.git
+            sudo ln -s ccache /usr/local/bin/mpic++
+            export PATH=/usr/lib/ccache:${PATH}
+            ccache -s
+            .ci/install.libtorch
+            # version=master or version=f123f12f3 to select a specific version
+            # The ordering is by version, so 2.10 will be > than 2.1 
+            CXX="mpic++" .ci/install.plumed version="$(cd plumed2.git ; git branch --list 'v2.*' --sort='version:refname'| sed "s/^ *//" | grep '^v2\.[0-9]*$' | tail -n 1)" repo=$PWD/plumed2.git
+            # GB: in addition, we install master version as plumed_master
+            CXX="mpic++" .ci/install.plumed version=master suffix=_master repo=$PWD/plumed2.git
+            ccache -s
   # This workflow contains a job called "build"
   build:
+    needs: setup
     strategy:
       matrix:
         replica: [0, 1]
@@ -21,13 +60,12 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v4
 
-    - uses: actions/cache@v4
+    - uses: actions/cache/restore@v4
       with:
         path: |
           ~/opt
           ~/.ccache
         key: ccache-${{ runner.os }}-${{ github.sha }}
-        restore-keys: ccache-${{ runner.os }}-
 
     - name: Set up Python 3.8
       uses: actions/setup-python@v5
@@ -57,13 +95,6 @@ jobs:
         git clone --bare https://github.com/plumed/plumed2.git
         sudo ln -s ccache /usr/local/bin/mpic++
         export PATH=/usr/lib/ccache:${PATH}
-        ccache -s
-        .ci/install.libtorch
-        # version=master or version=f123f12f3 to select a specific version
-        # The ordering is by version, so 2.10 will be > than 2.1 
-        CXX="mpic++" .ci/install.plumed version="$(cd plumed2.git ; git branch --list 'v2.*' --sort='version:refname'| sed "s/^ *//" | grep '^v2\.[0-9]*$' | tail -n 1)" repo=$PWD/plumed2.git
-        # GB: in addition, we install master version as plumed_master
-        CXX="mpic++" .ci/install.plumed version=master suffix=_master repo=$PWD/plumed2.git
         ccache -s
     - name: Build manual
       run: | 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,13 +12,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
+      - name: calculate cache key for the compilation
+        id: get-key
+        run: |
+          git clone --bare https://github.com/plumed/plumed2.git
+          stable=$(cd plumed2.git ; git branch --list 'v2.*' --sort='version:refname'| sed "s/^ *//" | grep '^v2\.[0-9]*$' | tail -n 1)
+          echo "key=$(cd plumed2.git ; git rev-parse "$stable")-$(cd plumed2.git ; git rev-parse master)" >> $GITHUB_OUTPUT
+
+      - name: setting up or retrieving the compilation cache
+        uses: actions/cache@v4
         with:
           path: |
             ~/opt
             ~/.ccache
-          key: ccache-${{ runner.os }}-${{ github.sha }}
+          key: ccache-${{ runner.os }}-${{ steps.get-key.outputs.key }}
           restore-keys: ccache-${{ runner.os }}-
+
       - name: Set paths
         run: |
               echo "$HOME/opt/bin" >> $GITHUB_PATH
@@ -97,15 +106,10 @@ jobs:
     - name: Install software
       run: |
         sudo apt update
-        sudo apt install mpi-default-bin mpi-default-dev
-        sudo apt install libfftw3-dev gsl-bin libgsl0-dev libboost-serialization-dev
-        sudo apt install ccache
+        sudo apt install mpi-default-bin
+        sudo apt install libfftw3 gsl-bin libgsl0 libboost-serialization
         sudo apt-get update
         pip install -r requirements.txt
-        git clone --bare https://github.com/plumed/plumed2.git
-        sudo ln -s ccache /usr/local/bin/mpic++
-        export PATH=/usr/lib/ccache:${PATH}
-        ccache -s
     - name: Build manual
       run: | 
         python --version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,8 +105,9 @@ jobs:
     - name: Install software
       run: |
         sudo apt update
-        sudo apt install mpi-default-bin
-        sudo apt install libfftw3 gsl-bin libgsl0 libboost-serialization
+        #shall we get non-dev version of these?
+        sudo apt install mpi-default-bin mpi-default-dev
+        sudo apt install libfftw3-dev gsl-bin libgsl0-dev libboost-serialization-dev
         sudo apt-get update
         pip install -r requirements.txt
     - name: Build manual

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,6 @@ jobs:
           path: |
             ~/opt
             ~/.ccache
-            ./_data
           key: ccache-${{ runner.os }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-
       - name: Set paths
@@ -48,6 +47,14 @@ jobs:
             # GB: in addition, we install master version as plumed_master
             CXX="mpic++" .ci/install.plumed version=master suffix=_master repo=$PWD/plumed2.git
             ccache -s
+      - name: caches the install results
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/opt
+            ./_data
+          key: build-${{ runner.os }}-${{ github.sha }}
+
   # This workflow contains a job called "build"
   build:
     needs: setup
@@ -66,9 +73,8 @@ jobs:
       with:
         path: |
           ~/opt
-          ~/.ccache
           ./_data
-        key: ccache-${{ runner.os }}-${{ github.sha }}
+        key: build-${{ runner.os }}-${{ github.sha }}
         fail-on-cache-miss: true
 
     - name: Set up Python 3.8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,9 +15,9 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: |
-            ~/opt
-            ~/.ccache
-            ~/_data
+            $HOME/opt
+            $HOME/.ccache
+            $GITHUB_WORKSPACE/_data
           key: ccache-${{ runner.os }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-
       - name: Set paths
@@ -65,9 +65,9 @@ jobs:
     - uses: actions/cache/restore@v4
       with:
         path: |
-          ~/opt
-          ~/.ccache
-          ~/_data
+          $HOME/opt
+          $HOME/.ccache
+          $GITHUB_WORKSPACE/_data
         key: ccache-${{ runner.os }}-${{ github.sha }}
 
     - name: Set up Python 3.8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
           path: |
             ~/opt
             ~/.ccache
+            ~/_data
           key: ccache-${{ runner.os }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-
       - name: Set paths
@@ -66,6 +67,7 @@ jobs:
         path: |
           ~/opt
           ~/.ccache
+          ~/_data
         key: ccache-${{ runner.os }}-${{ github.sha }}
 
     - name: Set up Python 3.8


### PR DESCRIPTION
With this the heavier compilation cache is disjointed from the actual code of the repo, gets update less often and does not risks of not being saved due to being created in parallel by two or more jobs like:
```
Failed to save: Unable to reserve cache with key ccache-Linux-80f6a8993274eda04b5ddcc7d381c1419053426a, another job may be creating this cache. More details: Cache already exists. Scope: refs/heads/improvingCI, Key: ccache-Linux-80f6a8993274eda04b5ddcc7d381c1419053426a, Version: c4dd56bb95be24c404aec9265247151de2de74780fac82c7ebd53a133832f3e7
```